### PR TITLE
Reproduction return in await using without braces in if statement has uncovered line

### DIFF
--- a/CoverletReproductions.Test/AwaitUsingReturnInIfStatementReproductionFixture.cs
+++ b/CoverletReproductions.Test/AwaitUsingReturnInIfStatementReproductionFixture.cs
@@ -1,0 +1,80 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace CoverletReproductions.Test;
+
+public class AwaitUsingReturnInIfStatementReproductionFixture
+{
+    [Fact]
+    public async Task ExecuteReproduction_HasUncoveredLine()
+    {
+        // Arrange
+        var sut = new AwaitUsingReturnInIfStatementReproduction();
+
+        // Act
+        int resultTrue = await sut.ExecuteReproduction(true);
+        int resultFalse = await sut.ExecuteReproduction(false);
+
+        // Assert
+        Assert.Equal(3, resultTrue);
+        Assert.Equal(1, resultFalse);
+    }
+
+    [Fact]
+    public async Task ExecuteNoIfStatement_AllCovered()
+    {
+        // Arrange
+        var sut = new AwaitUsingReturnInIfStatementReproduction();
+
+        // Act
+        int result = await sut.ExecuteNoIfStatement();
+
+        // Assert
+        Assert.Equal(3, result);
+    }
+
+    [Fact]
+    public async Task ExecuteAwaitUsingWithBraces_AllCovered()
+    {
+        // Arrange
+        var sut = new AwaitUsingReturnInIfStatementReproduction();
+
+        // Act
+        int resultTrue = await sut.ExecuteAwaitUsingWithBraces(true);
+        int resultFalse = await sut.ExecuteAwaitUsingWithBraces(false);
+
+        // Assert
+        Assert.Equal(3, resultTrue);
+        Assert.Equal(1, resultFalse);
+    }
+
+    [Fact]
+    public async Task ExecuteUsingWithoutAwait_AllCovered()
+    {
+        // Arrange
+        var sut = new AwaitUsingReturnInIfStatementReproduction();
+
+        // Act
+        int resultTrue = await sut.ExecuteUsingWithoutAwait(true);
+        int resultFalse = await sut.ExecuteUsingWithoutAwait(false);
+
+        // Assert
+        Assert.Equal(3, resultTrue);
+        Assert.Equal(1, resultFalse);
+    }
+
+    [Fact]
+    public async Task ExecuteReturnOutsideIfStatement_AllCovered()
+    {
+        // Arrange
+        var sut = new AwaitUsingReturnInIfStatementReproduction();
+
+        // Act
+        int resultTrue = await sut.ExecuteReturnOutsideIfStatement(true);
+        int resultFalse = await sut.ExecuteReturnOutsideIfStatement(false);
+
+        // Assert
+        Assert.Equal(3, resultTrue);
+        Assert.Equal(1, resultFalse);
+    }
+}

--- a/CoverletReproductions.Test/CoverletReproductions.Test.csproj
+++ b/CoverletReproductions.Test/CoverletReproductions.Test.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.1">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/CoverletReproductions/AwaitUsingReturnInIfStatementReproduction.cs
+++ b/CoverletReproductions/AwaitUsingReturnInIfStatementReproduction.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CoverletReproductions;
+
+public class AwaitUsingReturnInIfStatementReproduction
+{
+    public async Task<int> ExecuteReproduction(bool isTrue)
+    {
+        if (isTrue)
+        {
+            byte[] bytes = Encoding.ASCII.GetBytes("Words");
+            await using var stream = new MemoryStream(bytes);
+            var byteArray = new byte[stream.Length];
+            var count = await stream.ReadAsync(byteArray.AsMemory(0, 3));
+            return count;
+        }
+
+        return 1;
+    }
+
+    public async Task<int> ExecuteNoIfStatement()
+    {
+        byte[] bytes = Encoding.ASCII.GetBytes("Words");
+        await using var stream = new MemoryStream(bytes);
+        var byteArray = new byte[stream.Length];
+        var count = await stream.ReadAsync(byteArray.AsMemory(0, 3));
+        return count;
+    }
+
+    public async Task<int> ExecuteAwaitUsingWithBraces(bool isTrue)
+    {
+        if (isTrue)
+        {
+            byte[] bytes = Encoding.ASCII.GetBytes("Words");
+            await using (var stream = new MemoryStream(bytes))
+            {
+                var byteArray = new byte[stream.Length];
+                var count = await stream.ReadAsync(byteArray.AsMemory(0, 3));
+                return count;
+            }
+        }
+
+        return 1;
+    }
+
+    public async Task<int> ExecuteUsingWithoutAwait(bool isTrue)
+    {
+        if (isTrue)
+        {
+            byte[] bytes = Encoding.ASCII.GetBytes("Words");
+            using var stream = new MemoryStream(bytes);
+            var byteArray = new byte[stream.Length];
+            var count = await stream.ReadAsync(byteArray.AsMemory(0, 3));
+            return count;
+        }
+
+        return 1;
+    }
+
+    public async Task<int> ExecuteReturnOutsideIfStatement(bool isTrue)
+    {
+        int count = 1;
+        if (isTrue)
+        {
+            byte[] bytes = Encoding.ASCII.GetBytes("Words");
+            await using var stream = new MemoryStream(bytes);
+            var byteArray = new byte[stream.Length];
+            count = await stream.ReadAsync(byteArray.AsMemory(0, 3));
+        }
+
+        return count;
+    }
+}


### PR DESCRIPTION
To reproduce this line coverage error 4 different circumstances must be given
1. Use await using (only using works correct)
2. await using must be inside a if statement (maybe works with other statements too)
3. await using must be used without braces
4. A value must be returned in context of using inside the if statement