### PR TITLE
Reprodutction wrong branch coverage of two logicaly connected conditions

### DIFF
--- a/CoverletReproductions.Test/TwoConditionsBranchCoverageReproductionFixture.cs
+++ b/CoverletReproductions.Test/TwoConditionsBranchCoverageReproductionFixture.cs
@@ -1,0 +1,56 @@
+﻿using System.Collections.Generic;
+using Xunit;
+
+namespace CoverletReproductions.Test;
+
+public class TwoConditionsBranchCoverageReproductionFixture
+{
+    [Fact]
+    public void ExecuteReproduction_HasUncoveredBranch()
+    {
+        // Arrange
+        var sut = new TwoConditionsBranchCoverageReproduction();
+
+        // Act
+        // First condition is never true (number == 1) but both branches (return true/false) are covered by this test
+        sut.ExecuteReproduction(2);
+        sut.ExecuteReproduction(3);
+        // Uncomment to create a test case that covers all branches
+        // sut.ExecuteReproduction(1);
+
+        // Coverage is even worse here
+        sut.ExecuteReproduction2(2);
+        sut.ExecuteReproduction2(3);
+        // Uncomment to create a test case that covers all branches
+        // sut.ExecuteReproduction2(1);
+
+        // First condition is never true (number == 1) but both branches (return true/false) are covered by this test
+        sut.ExecuteReproduction3(2);
+        sut.ExecuteReproduction3(3);
+
+        // Can be reproduces with logical AND too.
+        // First condition is never false (number != null)
+        sut.ExecuteReproduction4(2);
+        sut.ExecuteReproduction4(3);
+
+        sut.ExecuteReturnBoolenValue(2);
+        sut.ExecuteReturnBoolenValue(3);
+
+        // Test identical methods where the second condition is never true (number == 2)
+        // This way the branch coverage is full
+        sut.ExecuteSecondAssertIsNeverTrue(1);
+        sut.ExecuteSecondAssertIsNeverTrue(3);
+
+        sut.ExecuteSecondAssertIsNeverTrue2(1);
+        sut.ExecuteSecondAssertIsNeverTrue2(3);
+
+        sut.ExecuteSecondAssertIsNeverTrue3(1);
+        sut.ExecuteSecondAssertIsNeverTrue3(3);
+
+        sut.ExecuteSecondAssertIsNeverTrue4(2);
+        sut.ExecuteSecondAssertIsNeverTrue4(null);
+
+        // Assert
+        // no assert
+    }
+}

--- a/CoverletReproductions/TwoConditionsBranchCoverageReproduction.cs
+++ b/CoverletReproductions/TwoConditionsBranchCoverageReproduction.cs
@@ -1,0 +1,67 @@
+﻿namespace CoverletReproductions;
+
+public class TwoConditionsBranchCoverageReproduction
+{
+    public bool ExecuteReproduction(int number)
+    {
+        return number == 1 || number == 2;
+    }
+
+    public bool ExecuteReproduction2(int number)
+    {
+        bool isTrue = number == 1 || number == 2;
+        return isTrue;
+    }
+
+    public bool ExecuteReproduction3(int number)
+    {
+        bool isTrue = number == 1 || number == 2;
+        if (isTrue)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    public bool ExecuteReproduction4(int? number)
+    {
+        return number != null && number == 2;
+    }
+
+    public bool ExecuteReturnBoolenValue(int number)
+    {
+        if (number == 1 || number == 2)
+        {
+            return true;
+        }
+        return false;
+    }
+
+    public bool ExecuteSecondAssertIsNeverTrue(int number)
+    {
+        return number == 1 || number == 2;
+    }
+
+    public bool ExecuteSecondAssertIsNeverTrue2(int number)
+    {
+        bool isTrue = number == 1 || number == 2;
+        return isTrue;
+    }
+
+    public bool ExecuteSecondAssertIsNeverTrue3(int number)
+    {
+        bool isTrue = number == 1 || number == 2;
+        if (isTrue)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    public bool ExecuteSecondAssertIsNeverTrue4(int? number)
+    {
+        return number != null && number == 2;
+    }
+}


### PR DESCRIPTION
Branch coverage fails if the first condition is never true (or connected), but the whole statement is tested to return true and false